### PR TITLE
Fix llvmlit and bottleneck issues

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -101,10 +101,10 @@ RUN mkdir /home/$NB_USER/work && \
     
 EXPOSE 8888
 
-RUN pip3 install -U setuptools
+RUN pip3 install -U setuptools wheel pip
 
 # Install jupyterlab and jupytext
-RUN pip3 install -U setuptools jupyterlab jupytext ipymd \
+RUN pip3 install -U jupyterlab jupytext ipymd \
     && jupyter lab build
    
 # install DOI root certificate so things work on the DOI network.

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -10,10 +10,6 @@ USER root
 RUN pip3 install -U --global-option=build_ext --global-option="-I/usr/include/gdal" GDAL==`gdal-config --version`
 
 RUN pip3 install -U \
-    scipy \
-    numpy
-
-RUN pip3 install \
     dask \
     bottleneck \
     netCDF4 \


### PR DESCRIPTION
This PR adds some of the missing dependencies for installing `llvmlite` and `bottleneck` using `pip3`.