### PR TITLE
Trigger the build and push action only on tagged commits

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,9 +1,8 @@
 name: Publish Docker
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [created]
 
 jobs:
   build:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,9 @@
 name: Publish Docker
 
-on: [push]
+on:
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+name: Create Release
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Please check the [HISTORY.md](HISTORY.md) file for a detailed list
+            of changes.
+          draft: false
+          prerelease: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 *.ipynb_checkpoints
 *rosm.cache
-*tags
+tags*

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,6 @@
 
 ## 0.1.0 (2020-08-31)
 
-- Add the `reticulate` package to the `R` image for compiling R Markdown file that include Python codes.
+- Add the `reticulate` package to the `R` image for compiling R Markdown files that include Python codes.
 - Update `nhdplusTools` and `PyNHD` packages to their latest versions.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,7 @@
+# History
+
+## 0.1.0 (2020-08-31)
+
+- Add the `reticulate` package to the `R` image for compiling R Markdown file that include Python codes.
+- Update `nhdplusTools` and `PyNHD` packages to their latest versions.
+

--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -65,6 +65,7 @@ RUN install2.r --error \
     systemfonts \
     leafpop \
     svglite \
+    reticulate \
     sbtools
 
 RUN apt-get update -qq \


### PR DESCRIPTION
This PR gives control over triggering the Publish on Docker Actions. Previously, every commit triggered a build which is not practical so with this PR the Actions is triggered only if the commit is tagged with a message that starts with `v`. For example:
```bash
version="v0.1.0" 
git tag -a "${version}" -m "${version}"
git push --follow-tags
```
It has another advantage as well. Whenever we want to update certain packages we just need to push a tagged commit.

Also, I added a file named `HISTORY.md` for logging the changes and helping with pushing tagged commits.

P.S. I have this function in my `.zshrc` file:
```bash
gta () {
	version="v$1" 
	git tag -a "${version}" -m "${version}"
	git push --follow-tags
}
```
So whenever I want to push a tagged commit I just have to run `gta v0.1.0` in my shell.