### PR TITLE
Install Hydrodata stack from Github

### DIFF
--- a/custom/Dockerfile
+++ b/custom/Dockerfile
@@ -12,6 +12,18 @@ RUN Rscript -e 'devtools::install_github("usgs-r/nhdplusTools")'
 
 RUN Rscript -e 'devtools::install_github("dblodgett-usgs/hyRefactor")'
 
+RUN install2.r --error reticulate
+
+RUN pip3 install -U \
+    mapclassify \
+    numpy \
+    git+https://github.com/cheginit/pygeoogc.git \
+    git+https://github.com/cheginit/pygeoutils.git \
+    git+https://github.com/cheginit/pynhd.git \
+    git+https://github.com/cheginit/py3dep.git \
+    git+https://github.com/cheginit/pydaymet.git \
+    git+https://github.com/cheginit/hydrodata.git
+
 # Switch back to jovyan to avoid accidental container runs as root
 USER $NB_UID
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -28,6 +28,7 @@ RUN pip3 install -U \
     numbagg \
     sympy \
     hydrodata \
+    mapclassify \
     git+https://github.com/eea/odfpy
 
 USER $NB_UID


### PR DESCRIPTION
This PR adds a couple of missing packages for knitting R Markdown with both Python and R codes. Additionally, the custom image now installs the Hydrodata stack from Github.